### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection in update-d1-changelog.js

### DIFF
--- a/update-d1-changelog.js
+++ b/update-d1-changelog.js
@@ -7,7 +7,7 @@
  * Used in GitHub Actions to keep the changelog current without full repopulation.
  */
 
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 console.log(' D1 Changelog Incremental Update\n');
 
@@ -78,17 +78,25 @@ async function getLatestD1Commit() {
 function getNewCommits(sinceHash) {
     console.log(' Getting new commits from git...');
     
-    let gitCommand;
+    // Validate the hash to prevent command injection
+    if (sinceHash && !/^[0-9a-fA-F]{7,40}$/.test(sinceHash)) {
+        console.error(' Invalid commit hash format received from D1');
+        return [];
+    }
+
+    const gitArgs = [
+        'log',
+        '--pretty=format:%H<|DELIM|>%B<|DELIM|>%ai<|DELIM|>%an<|DELIM|>%ae<|COMMIT_END|>',
+        '--reverse'
+    ];
+
     if (sinceHash) {
         // Get commits newer than the latest D1 commit
-        gitCommand = `git log --pretty=format:"%H<|DELIM|>%B<|DELIM|>%ai<|DELIM|>%an<|DELIM|>%ae<|COMMIT_END|>" ${sinceHash}..HEAD --reverse`;
-    } else {
-        // Get all commits (fallback)
-        gitCommand = `git log --pretty=format:"%H<|DELIM|>%B<|DELIM|>%ai<|DELIM|>%an<|DELIM|>%ae<|COMMIT_END|>" --reverse`;
+        gitArgs.splice(2, 0, `${sinceHash}..HEAD`);
     }
     
     try {
-        const gitOutput = execSync(gitCommand, { 
+        const gitOutput = execFileSync('git', gitArgs, {
             encoding: 'utf8',
             cwd: __dirname 
         });


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Command Injection in `update-d1-changelog.js`. The script was directly concatenating `sinceHash` (fetched from an external D1 API) into a `git log` shell command executed via `execSync`.
🎯 **Impact:** If the D1 API response is manipulated or contains shell metacharacters, it could lead to arbitrary shell command execution on the host machine running the script (e.g., during a CI/CD job).
🔧 **Fix:** Changed `execSync` to `execFileSync` to pass `git log` arguments as a secure array. Added regex validation (`/^[0-9a-fA-F]{7,40}$/`) for `sinceHash` to drop invalid/malicious input immediately. 
✅ **Verification:** Ran `node update-d1-changelog.js` which completed successfully with the hardened implementation. No regressions in functionality. Tested changes by requesting a code review.

---
*PR created automatically by Jules for task [5708074568986788599](https://jules.google.com/task/5708074568986788599) started by @degenai*