### PR TITLE
⚡ Bolt: Batch update leads to avoid N+1 KV writes during geocoding

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-09 - [N+1 KV Writes on Geocoding]
+**Learning:** Performing sequential updates (`CrmApi.updateLead()`) when modifying a collection of records loops triggers N+1 API and Cloudflare KV `saveState()` operations, which takes down performance heavily because `saveState()` writes the entire CRM blob at once.
+**Action:** Created `CrmApi.updateLeads()` to batch changes using a Map for O(1) index lookup and a single `saveState()`. Replaced the loop in `calculateRoute` to queue updates into an array, executing the single API call at the end of the loop.

--- a/js/crm/crm-api.js
+++ b/js/crm/crm-api.js
@@ -83,6 +83,31 @@ export const CrmApi = {
     return null;
   },
 
+  // ⚡ Bolt: Batch update multiple leads to avoid N+1 KV writes
+  async updateLeads(updates) {
+    if (!updates || updates.length === 0) return [];
+
+    // Create an O(1) lookup map for lead indices to optimize performance
+    const leadIndices = new Map();
+    this.localState.leads.forEach((lead, index) => {
+      leadIndices.set(lead.id, index);
+    });
+
+    const updatedLeads = [];
+    for (const update of updates) {
+      const index = leadIndices.get(update.id);
+      if (index !== undefined) {
+        this.localState.leads[index] = { ...this.localState.leads[index], ...update.data };
+        updatedLeads.push(this.localState.leads[index]);
+      }
+    }
+
+    if (updatedLeads.length > 0) {
+      await this.saveState();
+    }
+    return updatedLeads;
+  },
+
   async createLead(data) {
     const newLead = {
       ...data,

--- a/js/crm/utility.js
+++ b/js/crm/utility.js
@@ -390,6 +390,8 @@ async function calculateRoute() {
 
     if (leadsNeedingGeocode.length > 0) {
       let geocoded = 0;
+      const batchUpdates = []; // ⚡ Bolt: Collect updates to avoid N+1 KV writes
+
       for (const lead of leadsNeedingGeocode) {
         geocoded++;
         updateProgress(geocoded, leadsNeedingGeocode.length, `Geocoding ${lead.name}... (${geocoded}/${leadsNeedingGeocode.length})`);
@@ -397,9 +399,13 @@ async function calculateRoute() {
         const coords = await geocodeAddress(lead.address);
         if (coords) {
           lead.coords = coords;
-          // Update via CrmApi
-          await CrmApi.updateLead(lead.id, { coords });
+          batchUpdates.push({ id: lead.id, data: { coords } });
         }
+      }
+
+      // ⚡ Bolt: Execute a single batched update request
+      if (batchUpdates.length > 0) {
+        await CrmApi.updateLeads(batchUpdates);
       }
     }
 


### PR DESCRIPTION
💡 **What**: Created `CrmApi.updateLeads()` to batch changes using a Map for O(1) index lookup and a single `saveState()`. Replaced the loop in `calculateRoute` to queue updates into an array, executing the single API call at the end of the loop.
🎯 **Why**: Performing sequential updates (`CrmApi.updateLead()`) when modifying a collection of records loops triggers N+1 API and Cloudflare KV `saveState()` operations, which causes severe performance bottlenecks because `saveState()` writes the entire CRM blob at once.
📊 **Impact**: Reduces N network requests and KV writes to 1 when geocoding leads.
🔬 **Measurement**: It reduces N individual API requests from O(N) to O(1) reducing network latency significantly, the O(N) to O(1) network reduction is self-evident.

---
*PR created automatically by Jules for task [6220851479234244769](https://jules.google.com/task/6220851479234244769) started by @degenai*