### PR TITLE
🎨 Palette: Add keyboard focus states to custom buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-04-09 - Native Button vs Div for Mobile Menu Toggle
 **Learning:** When adding accessibility to legacy custom components (like a mobile menu toggle), it's highly preferred to refactor `div` elements into semantic `<button>` elements rather than adding `role="button"` and `tabindex="0"`. Native `<button>` elements inherently handle keyboard interactions (Space and Enter keys) and focus states, reducing custom JavaScript and styling overhead.
 **Action:** Prioritize transforming interactive `div`s into `<button>`s with necessary CSS resets (`background: none; border: none; padding: 0; color: inherit; font: inherit;`) over piling ARIA attributes onto non-semantic elements.
+
+## 2025-04-09 - Focus Visible on Custom Buttons
+**Learning:** Adding custom hover states and active states to button components (`.btn`, `.btn-icon`) often inadvertently overrides native focus states if not carefully managed. It's crucial to explicitly define `:focus-visible` states to ensure keyboard accessibility.
+**Action:** When working with custom interactive elements, especially those involving CSS transitions or transformations, always verify and add explicit `:focus-visible` styles that provide clear, high-contrast visual indicators for keyboard navigation, matching the design system's focus ring styles.

--- a/css/crm.css
+++ b/css/crm.css
@@ -156,6 +156,12 @@ body {
   transform: translateY(0);
 }
 
+.btn:focus-visible {
+  outline: 2px solid var(--pe-gold);
+  border-radius: 4px;
+  outline-offset: 2px;
+}
+
 .btn-primary {
   background: var(--pe-gold);
   color: var(--pe-green-dark);
@@ -1412,6 +1418,13 @@ body.page-loading .stat-card {
 
 .btn-icon:active {
   transform: scale(0.95);
+}
+
+.btn-icon:focus-visible,
+.btn-icon-sm:focus-visible {
+  outline: 2px solid var(--pe-gold);
+  border-radius: 4px;
+  outline-offset: 2px;
 }
 
 /* Status badge color transitions */


### PR DESCRIPTION
🎨 Palette: Add keyboard focus states to custom buttons

💡 What: Added `:focus-visible` styles with a clear golden outline (`--pe-gold`) to `.btn`, `.btn-icon`, and `.btn-icon-sm` classes in `css/crm.css`.
🎯 Why: To improve accessibility for keyboard users. Previously, the custom buttons lacked any focus indication because the custom active/hover states inadvertently overrode native browser focus styles.
📸 Before/After: (Visual change only, no Playwright required per user guidance)
♿ Accessibility: Ensures interactive custom buttons are visibly distinct when navigated via keyboard ('Tab'), adhering to WCAG focus visibility requirements.

---
*PR created automatically by Jules for task [14717794608868812819](https://jules.google.com/task/14717794608868812819) started by @degenai*