### PR TITLE
🧹 [code health improvement] Remove leftover console.log from update-d1-changelog.js

### DIFF
--- a/update-d1-changelog.js
+++ b/update-d1-changelog.js
@@ -9,7 +9,6 @@
 
 const { execFileSync } = require('child_process');
 
-console.log(' D1 Changelog Incremental Update\n');
 
 // Configuration
 const WRITER_WORKER_URL = process.env.WRITER_WORKER_URL || 'https://changelog-writer.alex-adamczyk.workers.dev'; // Updated to use dedicated writer worker


### PR DESCRIPTION
🎯 **What**
Removed a leftover `console.log(' D1 Changelog Incremental Update\n');` at line 12 of `update-d1-changelog.js`.

💡 **Why**
This log was noise and didn't provide any meaningful debugging value, as other functional logs already indicate the progress. Removing it cleans up the script's output and improves code health.

✅ **Verification**
Ran `node --check update-d1-changelog.js` to ensure the file parsed successfully and manually tested `node update-d1-changelog.js` to verify it ran without errors.

✨ **Result**
A cleaner command-line output for the automation script.

---
*PR created automatically by Jules for task [9356286782686779469](https://jules.google.com/task/9356286782686779469) started by @degenai*