### PR TITLE
🧹 [code health improvement] Remove leftover console.logs in geocoding.js

### DIFF
--- a/js/crm/geocoding.js
+++ b/js/crm/geocoding.js
@@ -169,7 +169,6 @@ async function geocodeAddress(address) {
   await waitForRateLimit();
   let result = await geocodeQuery(cleanAddress);
   if (result) {
-    console.log(`Geocoded (exact): ${cleanAddress}`);
     return { lat: result.lat, lon: result.lon };
   }
 
@@ -179,7 +178,6 @@ async function geocodeAddress(address) {
     await waitForRateLimit();
     result = await geocodeQuery(withoutZip);
     if (result) {
-      console.log(`Geocoded (without zip): ${withoutZip}`);
       return { lat: result.lat, lon: result.lon, approximate: true };
     }
   }
@@ -190,7 +188,6 @@ async function geocodeAddress(address) {
     await waitForRateLimit();
     result = await geocodeQuery(cityStateZip);
     if (result) {
-      console.log(`Geocoded (city/state): ${cityStateZip}`);
       return { lat: result.lat, lon: result.lon, approximate: true };
     }
   }
@@ -200,7 +197,6 @@ async function geocodeAddress(address) {
     await waitForRateLimit();
     result = await geocodeQuery(`${city}, ${state}`);
     if (result) {
-      console.log(`Geocoded (city only): ${city}, ${state}`);
       return { lat: result.lat, lon: result.lon, approximate: true };
     }
   }


### PR DESCRIPTION
🎯 **What**
Removed four leftover `console.log` debugging statements in the `geocodeAddress` function in `js/crm/geocoding.js`.

💡 **Why**
These statements were printing debugging information (e.g., "Geocoded (exact)", "Geocoded (without zip)") that creates unnecessary noise in the browser console. Removing them improves code cleanliness and maintainability.

✅ **Verification**
Verified that the removed statements were purely for debugging and did not affect any control flow or return values. The existing tests run fine without regressions.

✨ **Result**
Cleaner console output and a slightly cleaner geocoding module without debugging cruft.

---
*PR created automatically by Jules for task [10135208493173896909](https://jules.google.com/task/10135208493173896909) started by @degenai*