### PR TITLE
🧹 [remove leftover console.log in main.js]

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -208,7 +208,6 @@ document.addEventListener('DOMContentLoaded', function() {
             } else {
                 // Fallback in case main.js runs before components.js
                 // We'll let components.js handle the update when it loads
-                console.log('ComponentLoader not available yet, deferring version update');
             }
         } catch (error) {
             console.warn('Failed to fetch version from cache:', error);


### PR DESCRIPTION
🎯 **What:** Removed leftover `console.log` on line 211 in `js/main.js` that was used for debugging when `componentLoader` wasn't ready.
💡 **Why:** Reduces unnecessary console spam in production environments and removes leftover debug code, improving codebase cleanliness.
✅ **Verification:** Verified by checking bash output for `console.log` in `js/main.js`, running a syntax check via `node -c js/main.js`, and passing an automated review.
✨ **Result:** A cleaner `main.js` that doesn't output deferred update warnings to the user's console while maintaining exactly the same functionality.

---
*PR created automatically by Jules for task [13017028145338933537](https://jules.google.com/task/13017028145338933537) started by @degenai*