### PR TITLE
🧹 [code health improvement] Rephrase TODO-like comment in test-filtering.js

### DIFF
--- a/_deprecated/misc/test-filtering.js
+++ b/_deprecated/misc/test-filtering.js
@@ -81,7 +81,7 @@ console.log(`Commits kept: ${filtered.keptCommits}`);
 console.log(`Total commits displayed: ${filteredCommits.length}`);
 console.log('--- END OF FILTERING REPORT ---\n');
 
-// Fix any formatting issues in commit messages
+// Apply formatting fixes to commit messages
 const correctedCommits = filteredCommits.map(commit => {
     // Make a copy of the commit to avoid modifying the original
     const fixedCommit = {...commit};


### PR DESCRIPTION
Rephrased the comment `// Fix any formatting issues in commit messages` to `// Apply formatting fixes to commit messages` in `_deprecated/misc/test-filtering.js`. The previous phrasing sounded like a TODO item, which can trigger static analysis tools, but it was actually just a description of the logic directly below it.

---
*PR created automatically by Jules for task [16045341533482604262](https://jules.google.com/task/16045341533482604262) started by @degenai*