### PR TITLE
🧪 [testing improvement] Add tests for getTimeSince utility

### DIFF
--- a/js/crm/utils.js
+++ b/js/crm/utils.js
@@ -21,7 +21,7 @@ export function getTimeSince(dateStr) {
   else if (diffDays === 1) formatted = 'Yesterday';
   else if (diffDays < 7) formatted = `${diffDays} days ago`;
   else if (diffWeeks === 1) formatted = '1 week ago';
-  else if (diffWeeks < 4) formatted = `${diffWeeks} weeks ago`;
+  else if (diffDays < 30) formatted = `${diffWeeks} weeks ago`;
   else if (diffMonths === 1) formatted = '1 month ago';
   else formatted = `${diffMonths} months ago`;
 

--- a/js/crm/utils.test.js
+++ b/js/crm/utils.test.js
@@ -1,0 +1,71 @@
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { getTimeSince } from './utils.js';
+
+describe('getTimeSince', () => {
+  const fixedNow = new Date('2024-05-15T12:00:00Z');
+
+  test('returns Never when dateStr is falsy', () => {
+    const result = getTimeSince(null);
+    assert.deepStrictEqual(result, { days: Infinity, weeks: Infinity, formatted: 'Never' });
+  });
+
+  test('returns Today when diffDays is 0', (t) => {
+    t.mock.timers.enable({ apis: ['Date'], now: fixedNow });
+    const result = getTimeSince(new Date('2024-05-15T10:00:00Z').toISOString());
+    assert.strictEqual(result.formatted, 'Today');
+    assert.strictEqual(result.days, 0);
+  });
+
+  test('returns Yesterday when diffDays is 1', (t) => {
+    t.mock.timers.enable({ apis: ['Date'], now: fixedNow });
+    const result = getTimeSince(new Date('2024-05-14T12:00:00Z').toISOString());
+    assert.strictEqual(result.formatted, 'Yesterday');
+    assert.strictEqual(result.days, 1);
+  });
+
+  test('returns X days ago when diffDays < 7', (t) => {
+    t.mock.timers.enable({ apis: ['Date'], now: fixedNow });
+    const result = getTimeSince(new Date('2024-05-10T12:00:00Z').toISOString());
+    assert.strictEqual(result.formatted, '5 days ago');
+    assert.strictEqual(result.days, 5);
+  });
+
+  test('returns 1 week ago when diffWeeks is 1', (t) => {
+    t.mock.timers.enable({ apis: ['Date'], now: fixedNow });
+    const result = getTimeSince(new Date('2024-05-08T12:00:00Z').toISOString());
+    assert.strictEqual(result.formatted, '1 week ago');
+    assert.strictEqual(result.weeks, 1);
+  });
+
+  test('returns X weeks ago when diffWeeks < 4', (t) => {
+    t.mock.timers.enable({ apis: ['Date'], now: fixedNow });
+    const result = getTimeSince(new Date('2024-04-24T12:00:00Z').toISOString());
+    assert.strictEqual(result.formatted, '3 weeks ago');
+    assert.strictEqual(result.weeks, 3);
+  });
+
+  test('returns 4 weeks ago when diffDays is 28', (t) => {
+    t.mock.timers.enable({ apis: ['Date'], now: fixedNow });
+    const result = getTimeSince(new Date('2024-04-17T12:00:00Z').toISOString());
+    assert.strictEqual(result.formatted, '4 weeks ago');
+  });
+
+  test('returns 4 weeks ago when diffDays is 29', (t) => {
+    t.mock.timers.enable({ apis: ['Date'], now: fixedNow });
+    const result = getTimeSince(new Date('2024-04-16T12:00:00Z').toISOString());
+    assert.strictEqual(result.formatted, '4 weeks ago');
+  });
+
+  test('returns 1 month ago when diffMonths is 1', (t) => {
+    t.mock.timers.enable({ apis: ['Date'], now: fixedNow });
+    const result = getTimeSince(new Date('2024-04-15T12:00:00Z').toISOString());
+    assert.strictEqual(result.formatted, '1 month ago');
+  });
+
+  test('returns X months ago when diffMonths > 1', (t) => {
+    t.mock.timers.enable({ apis: ['Date'], now: fixedNow });
+    const result = getTimeSince(new Date('2024-02-15T12:00:00Z').toISOString());
+    assert.strictEqual(result.formatted, '3 months ago');
+  });
+});


### PR DESCRIPTION
🎯 **What:** The `getTimeSince` utility function in `js/crm/utils.js` lacked test coverage, which left it vulnerable to regressions and hidden edge-case bugs.
📊 **Coverage:** A new suite of unit tests (`js/crm/utils.test.js`) using `node:test` has been created, utilizing `t.mock.timers` for deterministic behavior. The tests cover falsy inputs, 0 days (Today), 1 day (Yesterday), X days ago, 1 week ago, X weeks ago, 4 weeks ago (28-29 days), 1 month ago, and X months ago.
✨ **Result:** 100% logic coverage of the `getTimeSince` function. Furthermore, writing these tests identified and safely fixed a hidden logic bug where 28 and 29 day differentials incorrectly returned "0 months ago" instead of "4 weeks ago". The condition was updated from `diffWeeks < 4` to `diffDays < 30`.

---
*PR created automatically by Jules for task [5598141031441769298](https://jules.google.com/task/5598141031441769298) started by @degenai*