### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## $(date +%Y-%m-%d) - Adding ARIA labels to icon-only buttons
+**Learning:** Found a widespread pattern in this app's components where icon-only buttons lacked ARIA labels (only having `title`). This is bad for screen reader accessibility. Added `aria-label` to these buttons.
+**Action:** Always ensure that icon-only buttons have an `aria-label` attribute in addition to a `title` attribute for screen readers.

--- a/crm.html
+++ b/crm.html
@@ -51,7 +51,7 @@
       </div>
       <div class="header-right">
         <button id="utilityBeltBtn" class="btn btn-utility" title="Utility Belt - Route Finder & Tools">🛠️ Utility Belt</button>
-        <button id="settingsBtn" class="btn btn-icon" title="Settings">⚙️</button>
+        <button id="settingsBtn" class="btn btn-icon" title="Settings" aria-label="Settings">⚙️</button>
         <button id="exportBtn" class="btn btn-secondary">Export JSON</button>
         <button id="importBtn" class="btn btn-secondary">Import JSON</button>
         <button id="addLeadBtn" class="btn btn-primary">+ New Lead</button>
@@ -148,7 +148,7 @@
               <option value="neighborhood">Sort: Neighborhood</option>
               <option value="created">Sort: Date Added</option>
             </select>
-            <button id="sortOrderBtn" class="btn btn-icon" title="Toggle sort order">↓</button>
+            <button id="sortOrderBtn" class="btn btn-icon" title="Toggle sort order" aria-label="Toggle sort order">↓</button>
           </div>
           <div class="list-count">
             <span id="leadCount">0 leads</span>
@@ -163,7 +163,7 @@
       <!-- Lead Detail Panel -->
       <aside id="detailPanel" class="detail-panel hidden">
         <div class="detail-header">
-          <button id="closeDetailBtn" class="btn btn-icon">✕</button>
+          <button id="closeDetailBtn" class="btn btn-icon" aria-label="Close lead details">✕</button>
           <h2 id="detailTitle">Lead Details</h2>
           <div class="detail-actions">
             <button id="editLeadBtn" class="btn btn-secondary">Edit</button>
@@ -181,7 +181,7 @@
     <footer class="console-panel">
       <div class="console-header">
         <span>📋 Activity Log</span>
-        <button id="toggleConsoleBtn" class="btn btn-icon btn-sm">▼</button>
+        <button id="toggleConsoleBtn" class="btn btn-icon btn-sm" aria-label="Toggle activity log">▼</button>
       </div>
       <div id="consoleContent" class="console-content">
         <!-- Log entries will appear here -->
@@ -193,7 +193,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h2 id="modalTitle">Add New Lead</h2>
-          <button id="closeModalBtn" class="btn btn-icon">✕</button>
+          <button id="closeModalBtn" class="btn btn-icon" aria-label="Close modal">✕</button>
         </div>
         <form id="leadForm" class="modal-body">
           <div class="form-row">
@@ -302,7 +302,7 @@
       <div class="modal-content modal-sm">
         <div class="modal-header">
           <h2 id="visitModalTitle">Log Visit</h2>
-          <button id="closeVisitModalBtn" class="btn btn-icon">✕</button>
+          <button id="closeVisitModalBtn" class="btn btn-icon" aria-label="Close visit modal">✕</button>
         </div>
         <form id="visitForm" class="modal-body">
           <div class="form-group">
@@ -336,7 +336,7 @@
       <div class="modal-content modal-sm modal-danger">
         <div class="modal-header">
           <h2>⚠️ Delete Visit?</h2>
-          <button id="closeDeleteVisitBtn" class="btn btn-icon">✕</button>
+          <button id="closeDeleteVisitBtn" class="btn btn-icon" aria-label="Close delete visit confirmation">✕</button>
         </div>
         <div class="modal-body">
           <p class="delete-warning">This action cannot be undone.</p>
@@ -359,7 +359,7 @@
       <div class="modal-content modal-sm">
         <div class="modal-header">
           <h2>⚙️ Settings</h2>
-          <button id="closeSettingsModalBtn" class="btn btn-icon">✕</button>
+          <button id="closeSettingsModalBtn" class="btn btn-icon" aria-label="Close settings modal">✕</button>
         </div>
         <div class="modal-body">
           <div class="form-group">

--- a/js/crm/renderer.js
+++ b/js/crm/renderer.js
@@ -590,8 +590,8 @@ function renderDetailPanel(lead) {
             <div class="visit-header">
               <span class="visit-date">${formatDate(visit.date)}</span>
               <div class="visit-actions">
-                <button class="btn-icon-sm" data-action="edit-visit" data-lead-id="${lead.id}" data-visit-index="${originalIndex}" title="Edit visit">✏️</button>
-                <button class="btn-icon-sm btn-danger-subtle" data-action="delete-visit" data-lead-id="${lead.id}" data-visit-index="${originalIndex}" title="Delete visit">🗑️</button>
+                <button class="btn-icon-sm" data-action="edit-visit" data-lead-id="${lead.id}" data-visit-index="${originalIndex}" title="Edit visit" aria-label="Edit visit">✏️</button>
+                <button class="btn-icon-sm btn-danger-subtle" data-action="delete-visit" data-lead-id="${lead.id}" data-visit-index="${originalIndex}" title="Delete visit" aria-label="Delete visit">🗑️</button>
                 <span class="visit-reception">${getReceptionEmoji(visit.reception)} ${visit.reception}</span>
               </div>
             </div>
@@ -934,7 +934,7 @@ function renderFormContacts() {
             <input type="radio" name="primaryContact" ${contact.isPrimary ? 'checked' : ''} data-action="set-primary-contact" data-index="${index}">
             <span class="primary-label">${contact.isPrimary ? '★ Primary' : 'Set Primary'}</span>
           </label>
-          <button type="button" class="btn btn-icon btn-sm remove-contact-btn" data-action="remove-contact" data-index="${index}" title="Remove contact">✕</button>
+          <button type="button" class="btn btn-icon btn-sm remove-contact-btn" data-action="remove-contact" data-index="${index}" title="Remove contact" aria-label="Remove contact">✕</button>
         </div>
         <div class="contact-card-fields">
           <div class="form-row">

--- a/utility.html
+++ b/utility.html
@@ -582,7 +582,7 @@
     <!-- Header -->
     <header class="utility-header">
       <div class="header-left">
-        <button id="backBtn" class="back-btn" title="Back to Lead-o-Tron">←</button>
+        <button id="backBtn" class="back-btn" title="Back to Lead-o-Tron" aria-label="Back to Lead-o-Tron">←</button>
         <h1 class="utility-title">🛠️ Utility Belt</h1>
       </div>
     </header>


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to icon-only buttons across the application (`crm.html`, `utility.html`, and dynamically rendered buttons in `js/crm/renderer.js`).

🎯 **Why:** To improve accessibility for screen reader users. Icon-only buttons lacked a clear, accessible text description, making navigation difficult for those using assistive technologies.

📸 **Before/After:**
*(Visuals remain unchanged. Semantic HTML is updated.)*
**Before:** `<button class="btn btn-icon">✕</button>`
**After:** `<button class="btn btn-icon" aria-label="Close modal">✕</button>`

♿ **Accessibility:** Sighted users still benefit from the `title` tooltips, while screen reader users now get clear, programmatic descriptions of the button actions via `aria-label`.

---
*PR created automatically by Jules for task [7126617127156520461](https://jules.google.com/task/7126617127156520461) started by @degenai*