### PR TITLE
🎨 Palette: Add :focus-visible to anchor tags for keyboard navigation

### DIFF
--- a/css/changelog.css
+++ b/css/changelog.css
@@ -612,6 +612,12 @@
     text-decoration: underline;
 }
 
+a:focus-visible {
+    outline: 2px solid #CE9C00;
+    border-radius: 4px;
+    outline-offset: 4px;
+}
+
 .changelog-explanation a:hover {
     color: #fff;
 }

--- a/css/crm.css
+++ b/css/crm.css
@@ -162,6 +162,12 @@ body {
   outline-offset: 2px;
 }
 
+a:focus-visible {
+  outline: 2px solid var(--pe-gold);
+  border-radius: 4px;
+  outline-offset: 2px;
+}
+
 .btn-primary {
   background: var(--pe-gold);
   color: var(--pe-green-dark);

--- a/css/main.css
+++ b/css/main.css
@@ -50,6 +50,12 @@ a {
     transition: color 0.3s ease;
 }
 
+a:focus-visible {
+    outline: 2px solid var(--pe-gold);
+    border-radius: 4px;
+    outline-offset: 4px;
+}
+
 a:hover {
     color: var(--pe-green-light);
 }


### PR DESCRIPTION
**💡 What**
Added an `a:focus-visible` CSS rule across `main.css`, `crm.css`, and `changelog.css` to provide a consistent, clear focus outline on anchor tags.

**🎯 Why**
Previously, navigating the site using a keyboard (e.g., using the Tab key) provided no clear visual indication of focus on link elements. This made the site difficult to navigate for users relying on keyboard access. Using the `:focus-visible` pseudo-class ensures that this outline only appears for keyboard users, preventing unwanted focus rings for users clicking with a mouse.

**📸 Before/After**
- Before: Tabbing through links resulted in invisible or default browser styling, blending into the background.
- After: Tabbing through links now produces a clear, high-contrast gold outline (matching button focus states).

**♿ Accessibility**
Greatly improves keyboard accessibility for navigation links, ensuring users can clearly see which element has focus.

---
*PR created automatically by Jules for task [6965394950136919988](https://jules.google.com/task/6965394950136919988) started by @degenai*