### PR TITLE
🎨 Palette: Improve accessibility with explicit form labels and focus states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-04-10 - Adding :focus-visible to interactive elements
 **Learning:** Implementing `:focus-visible` styles using existing brand colors (like `var(--pe-gold)`) provides a huge accessibility win for keyboard navigation while maintaining visual design for mouse users, a practice often overlooked in custom UI.
 **Action:** Always verify keyboard focus states and add `:focus-visible` to interactive elements like buttons and links to ensure keyboard navigation is clear and accessible.
+
+## 2026-04-10 - Explicitly associating form labels with for attributes
+**Learning:** Adding `for` attributes to `<label>` elements linking them to their corresponding `id` of an `<input>`, `<select>`, or `<textarea>` is critical. Implicit labels or standalone labels are not consistently interpreted correctly by screen readers, particularly when they are separated by DOM hierarchy or when dealing with complex input widgets like `<input type="range">`.
+**Action:** Always guarantee that `<label>` tags use a explicit `for="[id]"` attribute that accurately references their input, ensuring proper programmatic association.

--- a/crm.html
+++ b/crm.html
@@ -67,7 +67,7 @@
           <h3>🔍 Filters</h3>
 
           <div class="filter-group">
-            <label>Status</label>
+            <label for="filterStatus">Status</label>
             <select id="filterStatus">
               <option value="all">All Status</option>
               <option value="active" selected>Active</option>
@@ -77,7 +77,7 @@
           </div>
 
           <div class="filter-group">
-            <label>Time Since Visit</label>
+            <label for="filterTime">Time Since Visit</label>
             <select id="filterTime">
               <option value="all">All Time</option>
               <option value="week">This Week</option>
@@ -90,20 +90,20 @@
           </div>
 
           <div class="filter-group">
-            <label>Neighborhood</label>
+            <label for="filterNeighborhood">Neighborhood</label>
             <select id="filterNeighborhood">
               <option value="all">All Areas</option>
             </select>
           </div>
 
           <div class="filter-group">
-            <label>Min Score</label>
+            <label for="filterMinScore">Min Score</label>
             <input type="range" id="filterMinScore" min="3" max="15" value="3">
             <span id="filterMinScoreValue">3+</span>
           </div>
 
           <div class="filter-group">
-            <label>Last Reception</label>
+            <label for="filterReception">Last Reception</label>
             <select id="filterReception">
               <option value="all">All</option>
               <option value="warm">🔥 Warm</option>
@@ -240,17 +240,17 @@
             <h3>Scores</h3>
             <div class="scores-grid">
               <div class="score-group">
-                <label>🪑 Space <span id="spaceValue">3</span>/5</label>
+                <label for="scoreSpace">🪑 Space <span id="spaceValue">3</span>/5</label>
                 <input type="range" id="scoreSpace" min="1" max="5" value="3">
                 <small>Room for chair massage setup</small>
               </div>
               <div class="score-group">
-                <label>👥 Traffic <span id="trafficValue">3</span>/5</label>
+                <label for="scoreTraffic">👥 Traffic <span id="trafficValue">3</span>/5</label>
                 <input type="range" id="scoreTraffic" min="1" max="5" value="3">
                 <small>Customer foot traffic</small>
               </div>
               <div class="score-group">
-                <label>✨ Vibes <span id="vibesValue">3</span>/5</label>
+                <label for="scoreVibes">✨ Vibes <span id="vibesValue">3</span>/5</label>
                 <input type="range" id="scoreVibes" min="1" max="5" value="3">
                 <small>Cultural fit / mutual aid alignment</small>
               </div>
@@ -263,7 +263,7 @@
           <div id="quickVisitSection" class="form-section">
             <h3>Quick Add Visit</h3>
             <div class="form-group">
-              <label>
+              <label for="addQuickVisit">
                 <input type="checkbox" id="addQuickVisit"> Log a visit now
               </label>
             </div>

--- a/css/crm.css
+++ b/css/crm.css
@@ -1482,3 +1482,21 @@ input:focus, textarea:focus, select:focus {
   box-shadow: 0 0 0 2px rgba(255, 199, 44, 0.3);
   transition: box-shadow 0.2s ease;
 }
+
+input:focus-visible, textarea:focus-visible, select:focus-visible {
+  outline: 2px solid var(--pe-gold);
+  border-radius: 4px;
+  outline-offset: 2px;
+}
+
+a:focus-visible {
+  outline: 2px solid var(--pe-gold);
+  border-radius: 4px;
+  outline-offset: 2px;
+}
+
+button:focus-visible {
+  outline: 2px solid var(--pe-gold);
+  border-radius: 4px;
+  outline-offset: 2px;
+}

--- a/js/crm/renderer.js
+++ b/js/crm/renderer.js
@@ -951,22 +951,22 @@ function renderFormContacts() {
         <div class="contact-card-fields">
           <div class="form-row">
             <div class="form-group flex-grow">
-              <label>Name</label>
-              <input type="text" value="${escapeHtml(contact.name)}" data-action="update-contact" data-index="${index}" data-field="name" placeholder="Contact name">
+              <label for="contact-name-${index}">Name</label>
+              <input type="text" id="contact-name-${index}" value="${escapeHtml(contact.name)}" data-action="update-contact" data-index="${index}" data-field="name" placeholder="Contact name">
             </div>
             <div class="form-group flex-grow">
-              <label>Role</label>
-              <input type="text" value="${escapeHtml(contact.role)}" data-action="update-contact" data-index="${index}" data-field="role" placeholder="Position/title">
+              <label for="contact-role-${index}">Role</label>
+              <input type="text" id="contact-role-${index}" value="${escapeHtml(contact.role)}" data-action="update-contact" data-index="${index}" data-field="role" placeholder="Position/title">
             </div>
           </div>
           <div class="form-row">
             <div class="form-group flex-grow">
-              <label>Phone</label>
-              <input type="tel" value="${escapeHtml(contact.phone)}" data-action="update-contact" data-index="${index}" data-field="phone" placeholder="Phone number">
+              <label for="contact-phone-${index}">Phone</label>
+              <input type="tel" id="contact-phone-${index}" value="${escapeHtml(contact.phone)}" data-action="update-contact" data-index="${index}" data-field="phone" placeholder="Phone number">
             </div>
             <div class="form-group flex-grow">
-              <label>Email</label>
-              <input type="email" value="${escapeHtml(contact.email)}" data-action="update-contact" data-index="${index}" data-field="email" placeholder="Email address">
+              <label for="contact-email-${index}">Email</label>
+              <input type="email" id="contact-email-${index}" value="${escapeHtml(contact.email)}" data-action="update-contact" data-index="${index}" data-field="email" placeholder="Email address">
             </div>
           </div>
         </div>


### PR DESCRIPTION
💡 **What**
Added explicit `for` attributes to form labels across `crm.html` and the dynamically generated contact cards in `js/crm/renderer.js`. Additionally, updated `css/crm.css` to provide high-contrast `:focus-visible` outlines for inputs, textareas, selects, buttons, and links. 

🎯 **Why**
Labels missing `for` attributes fail to properly associate with their corresponding input fields, making it difficult for screen readers to interpret the forms. Adding `:focus-visible` styles provides clear visual indicators for users navigating via keyboard, without interfering with mouse click behavior.

📸 **Before/After**
*Before:* Inputs and ranges had standalone labels lacking `for` bindings. Keyboard focus on inputs/buttons did not consistently display a clear outline.
*After:* All labels successfully target their specific inputs. A visible gold focus ring appears when navigating elements via the `Tab` key.

♿ **Accessibility**
- Resolved orphaned labels affecting screen reader experiences in forms.
- Introduced reliable keyboard navigation focus rings for all standard interactive inputs.

---
*PR created automatically by Jules for task [6451043608861885382](https://jules.google.com/task/6451043608861885382) started by @degenai*