### PR TITLE
🎨 Palette: Add keyboard navigation to console toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-04-10 - Adding :focus-visible to interactive elements
 **Learning:** Implementing `:focus-visible` styles using existing brand colors (like `var(--pe-gold)`) provides a huge accessibility win for keyboard navigation while maintaining visual design for mouse users, a practice often overlooked in custom UI.
 **Action:** Always verify keyboard focus states and add `:focus-visible` to interactive elements like buttons and links to ensure keyboard navigation is clear and accessible.
+## 2026-04-12 - Missing keyboard events for elements with role="button"
+**Learning:** Elements styled as buttons using `role="button"` and `tabindex="0"` (like `.console-header` in this app) are often given `click` event listeners but miss the `keydown` handlers for 'Enter' and 'Space'. This completely blocks keyboard users from interacting with them.
+**Action:** When inspecting non-native semantic elements that have interactive roles, always ensure they have both `click` and `keydown` event listeners, and ensure focus visible states are correctly defined in CSS.

--- a/css/crm.css
+++ b/css/crm.css
@@ -783,6 +783,11 @@ body {
   user-select: none;
 }
 
+.console-header:focus-visible {
+  outline: 2px solid var(--pe-gold);
+  outline-offset: -2px;
+}
+
 .console-toggle-arrow {
   font-size: 14px;
   transition: transform 0.2s ease;

--- a/js/crm/renderer.js
+++ b/js/crm/renderer.js
@@ -378,7 +378,14 @@ function setupEventListeners() {
   elements.saveSettingsBtn.addEventListener('click', handleSaveSettings);
 
   // Console toggle - whole header bar is clickable
-  document.querySelector('.console-header').addEventListener('click', toggleConsole);
+  const consoleHeader = document.querySelector('.console-header');
+  consoleHeader.addEventListener('click', toggleConsole);
+  consoleHeader.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggleConsole();
+    }
+  });
 
   // Keyboard shortcuts
   document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
💡 What: Added 'Enter' and 'Space' key support to the console header toggle, along with a `:focus-visible` ring.
🎯 Why: Elements acting like buttons with `role="button"` need explicit keyboard listeners to be accessible to users who do not use a mouse.
📸 Before/After: Visual outline added for keyboard focus.
♿ Accessibility: Ensures full keyboard interaction for the activity log toggle, resolving a key a11y trap.

---
*PR created automatically by Jules for task [2717902008243956376](https://jules.google.com/task/2717902008243956376) started by @degenai*