### PR TITLE
⚡ Bolt: Cache D1 changelog entries in sessionStorage

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,7 @@ The following changes have been proposed and rejected TWICE (2026-04-11, 2026-04
 - Replacing `.map().join('')` with `for` loop string concatenation in `renderLeadList()` or `renderActivityLog()` — no measurable performance difference at this scale
 - Wrapping template literal sections in IIFEs to avoid `.map().join('')` — makes code harder to read for zero gain
 - Any change that increases line count without improving readability or fixing a real bottleneck
+
+## 2026-04-12 - [Client-Side Data Caching with sessionStorage]
+**Learning:** For application views populated by external API calls (e.g., the D1 changelog or statically loaded components), fetching the same unchanging data on every page navigation causes redundant network requests and slower rendering.
+**Action:** Use `sessionStorage` to cache API responses and component states locally within the browser session, allowing near-instantaneous re-renders when users navigate back to the page.

--- a/js/d1-changelog.js
+++ b/js/d1-changelog.js
@@ -27,6 +27,26 @@ class D1Changelog {
     async loadChangelog(page = 0) {
         if (this.isLoading) return;
         
+        // 1. Try to load from sessionStorage cache if page 0
+        if (page === 0) {
+            try {
+                const cachedData = sessionStorage.getItem('d1_changelog_cache');
+                if (cachedData) {
+                    const parsed = JSON.parse(cachedData);
+                    this.allData = parsed.allData;
+                    this.totalCount = parsed.totalCount;
+                    this.hasMore = parsed.hasMore;
+                    this.currentPage = parsed.currentPage;
+                    this.displayVersionNumber();
+                    this.displayChangelog();
+                    return; // Skip fetch since we have cached data
+                }
+            } catch (e) {
+                console.warn('Failed to parse changelog cache:', e);
+                // Continue to fetch if cache fails
+            }
+        }
+
         this.isLoading = true;
         this.showLoading();
 
@@ -56,6 +76,18 @@ class D1Changelog {
             this.hasMore = data.pagination.hasMore;
             this.currentPage = page;
             
+            // 2. Save to sessionStorage cache after updating state
+            try {
+                sessionStorage.setItem('d1_changelog_cache', JSON.stringify({
+                    allData: this.allData,
+                    totalCount: this.totalCount,
+                    hasMore: this.hasMore,
+                    currentPage: this.currentPage
+                }));
+            } catch (e) {
+                console.warn('Failed to save changelog cache:', e);
+            }
+
             this.displayChangelog();
             
         } catch (error) {


### PR DESCRIPTION
💡 **What**
Implemented a client-side caching layer using `sessionStorage` in `js/d1-changelog.js` for the D1 Changelog data.

🎯 **Why**
Previously, navigating away from the changelog page and returning would trigger a fresh network request to the Cloudflare Worker, resetting the pagination and fetching the same 20 entries again. This avoids redundant API calls and provides an instant UI update on return visits.

📊 **Impact**
- Eliminates 1 unnecessary network request per return visit to the changelog page.
- Preserves the user's pagination state (if they clicked "Load More", all loaded entries are instantly restored from cache).
- Saves bandwidth and API quota on the Cloudflare Worker side.

🔬 **Measurement**
1. Open the Network tab in DevTools.
2. Navigate to the Changelog page; observe the `fetch` to `changelog-reader`.
3. Navigate to Home, then back to the Changelog.
4. Observe that no new network request is made to the worker and the changelog renders instantly.

---
*PR created automatically by Jules for task [14615192968032341095](https://jules.google.com/task/14615192968032341095) started by @degenai*