### PR TITLE
Spread the visual flair site-wide and a tidy SEO/a11y/copy mop-up

### DIFF
--- a/book.html
+++ b/book.html
@@ -14,6 +14,13 @@
     <meta property="og:description" content="Online booking for licensed chair and table massage in Woodstock, GA. No upselling, no membership traps.">
     <meta property="og:image" content="https://peoples-elbow.com/images/logo.png">
 
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://peoples-elbow.com/book.html">
+    <meta name="twitter:title" content="Book a Session | The People's Elbow">
+    <meta name="twitter:description" content="Online booking for licensed chair and table massage in Woodstock, GA. No upselling, no membership traps.">
+    <meta name="twitter:image" content="https://peoples-elbow.com/images/logo.png">
+
     <link rel="shortcut icon" href="images/favicon-32.png" type="image/png">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Bangers&family=Open+Sans:wght@400;700&display=swap">
@@ -85,5 +92,6 @@
     <!-- JavaScript -->
     <script src="js/components.js"></script>
     <script src="js/main.js"></script>
+    <script type="module" src="js/reveal.js"></script>
 </body>
 </html>

--- a/calendar.html
+++ b/calendar.html
@@ -78,5 +78,6 @@
     <!-- JavaScript -->
     <script src="js/components.js"></script>
     <script src="js/main.js"></script>
+    <script type="module" src="js/reveal.js"></script>
 </body>
 </html>

--- a/changelog.html
+++ b/changelog.html
@@ -39,7 +39,7 @@
     
     <main>
         <section class="changelog-hero">
-            <h1>D1 CHANGELOG <i class="fas fa-database"></i></h1>
+            <h1>D1 CHANGELOG <i aria-hidden="true" class="fas fa-database"></i></h1>
             <h2>"OH MY GOD! IS THAT... YES! THE PEOPLE'S ELBOW IS ENTERING THE DEVELOPMENT RING WITH A STEEL CHAIR FULL OF COMMITS!"</h2>
             <div id="current-version">
                 <span class="version-label">CURRENT BUILD:</span> 

--- a/chat.html
+++ b/chat.html
@@ -4,6 +4,23 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Community Chat | The People's Elbow</title>
+    <meta name="description" content="IRC-style community chat coming soon to The People's Elbow. Real-time conversations without algorithmic feeds. Join us on Instagram while we build.">
+    <link rel="canonical" href="https://peoples-elbow.com/chat.html">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://peoples-elbow.com/chat.html">
+    <meta property="og:title" content="Community Chat | The People's Elbow">
+    <meta property="og:description" content="IRC-style community chat coming soon. Real-time conversations without algorithmic feeds.">
+    <meta property="og:image" content="https://peoples-elbow.com/images/logo.png">
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://peoples-elbow.com/chat.html">
+    <meta name="twitter:title" content="Community Chat | The People's Elbow">
+    <meta name="twitter:description" content="IRC-style community chat coming soon. Real-time conversations without algorithmic feeds.">
+    <meta name="twitter:image" content="https://peoples-elbow.com/images/logo.png">
+
     <link rel="shortcut icon" href="images/favicon-32.png" type="image/png">
     
     <!-- Font Awesome for icons -->

--- a/crm.html
+++ b/crm.html
@@ -36,7 +36,7 @@
     <!-- Demo data banner — hidden once Drive connects or data is cleared -->
     <div id="demo-banner" class="demo-banner hidden">
       <div class="demo-banner-text">
-        <strong>Demo mode</strong> — you're viewing fictional sample data.
+        <strong>Demo mode</strong>: you're viewing fictional sample data.
         <span class="demo-banner-options">
           Sign in with Google to load your real leads and sync to Drive.
           Or <button id="importBtnBanner" class="demo-banner-link">import a JSON file</button> to use the CRM locally without Google.

--- a/css/main.css
+++ b/css/main.css
@@ -139,6 +139,47 @@ p {
     vector-effect: non-scaling-stroke;
 }
 
+/* Price-Drop Pin (price-drop.js, steal page): a gold slash drawn over the "$200" */
+.pe-price-strike {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+    pointer-events: none;
+}
+
+.pe-price-strike path {
+    fill: none;
+    stroke: var(--pe-gold);
+    stroke-width: 3;
+    stroke-linecap: round;
+    vector-effect: non-scaling-stroke;
+}
+
+/* Cross-page "tag-in" transition. Progressive enhancement: Chromium animates it;
+   other browsers and reduced-motion users hard-navigate exactly as before. */
+@view-transition {
+    navigation: auto;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    ::view-transition-old(root) {
+        animation: pe-tag-out 160ms cubic-bezier(0.4, 0, 1, 1) both;
+    }
+    ::view-transition-new(root) {
+        animation: pe-tag-in 240ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    }
+    @keyframes pe-tag-out {
+        to { opacity: 0; transform: translateX(-1.5%); }
+    }
+    @keyframes pe-tag-in {
+        from { opacity: 0; clip-path: inset(0 0 0 100%); }
+        to { opacity: 1; clip-path: inset(0 0 0 0); }
+    }
+}
+
 /* Buttons */
 .btn {
     display: inline-block;

--- a/dashboard.html
+++ b/dashboard.html
@@ -55,7 +55,7 @@
     <main class="wip-main">
         <div class="container">
             <div class="wip-hero">
-                <i class="fas fa-tools wip-icon"></i>
+                <i aria-hidden="true" class="fas fa-tools wip-icon"></i>
                 <h1>🛠️ Admin Dashboard</h1>
                 <p class="wip-subtitle">Database Management & Site Tools</p>
             </div>
@@ -64,7 +64,7 @@
                 <div class="dashboard-grid">
                     <a href="crm.html" class="dashboard-card" style="text-decoration: none; color: inherit;">
                         <div class="card-icon">
-                            <i class="fas fa-users"></i>
+                            <i aria-hidden="true" class="fas fa-users"></i>
                         </div>
                         <h3>Lead-o-Tron 5000</h3>
                         <p>CRM and route planning tool for managing venue outreach, logging visits, and tracking leads.</p>
@@ -72,7 +72,7 @@
 
                     <div class="dashboard-card">
                         <div class="card-icon">
-                            <i class="fas fa-database"></i>
+                            <i aria-hidden="true" class="fas fa-database"></i>
                         </div>
                         <h3>Database Manager</h3>
                         <p>Add, edit, and manage calendar events, locations, and site content stored in D1 database.</p>
@@ -81,7 +81,7 @@
 
                     <div class="dashboard-card">
                         <div class="card-icon">
-                            <i class="fas fa-map-marked-alt"></i>
+                            <i aria-hidden="true" class="fas fa-map-marked-alt"></i>
                         </div>
                         <h3>Location Manager</h3>
                         <p>Add new venues, update location details, and manage the interactive map data.</p>
@@ -90,7 +90,7 @@
 
                     <div class="dashboard-card">
                         <div class="card-icon">
-                            <i class="fas fa-envelope-open-text"></i>
+                            <i aria-hidden="true" class="fas fa-envelope-open-text"></i>
                         </div>
                         <h3>Contact Manager</h3>
                         <p>View and respond to contact form submissions and host interest requests.</p>
@@ -99,7 +99,7 @@
 
                     <div class="dashboard-card">
                         <div class="card-icon">
-                            <i class="fas fa-chart-line"></i>
+                            <i aria-hidden="true" class="fas fa-chart-line"></i>
                         </div>
                         <h3>Analytics</h3>
                         <p>Track site usage, form submissions, and community impact metrics.</p>
@@ -108,7 +108,7 @@
 
                     <div class="dashboard-card">
                         <div class="card-icon">
-                            <i class="fas fa-code-branch"></i>
+                            <i aria-hidden="true" class="fas fa-code-branch"></i>
                         </div>
                         <h3>Dev Tools</h3>
                         <p>Deploy updates, manage changelog entries, and monitor site performance.</p>

--- a/index.html
+++ b/index.html
@@ -89,17 +89,17 @@
                     <p>The 50/50 split with host venues keeps incentives aligned long-term. Money spent locally stays local: host venues, therapist, community all in one loop.</p>
                     <div class="values">
                         <div class="value-item">
-                            <i class="fas fa-balance-scale"></i>
+                            <i aria-hidden="true" class="fas fa-balance-scale"></i>
                             <h3>No Mission Creep</h3>
                             <p>We amplify local causes without imposing our own agenda.</p>
                         </div>
                         <div class="value-item">
-                            <i class="fas fa-hands-helping"></i>
+                            <i aria-hidden="true" class="fas fa-hands-helping"></i>
                             <h3>Mutual Aid over Branding</h3>
                             <p>We serve communities without collecting emails or upselling packages.</p>
                         </div>
                         <div class="value-item">
-                            <i class="fas fa-theater-masks"></i>
+                            <i aria-hidden="true" class="fas fa-theater-masks"></i>
                             <h3>Kayfabe with Integrity</h3>
                             <p>Our superhero persona makes care approachable with sincere intentions.</p>
                         </div>
@@ -128,20 +128,20 @@
                         </p>
                         <div style="background: linear-gradient(135deg, #f0f8f0 0%, #e8f5e8 100%); padding: 1.5rem; border-radius: 8px; border-left: 4px solid var(--pe-green); box-shadow: 0 2px 8px rgba(0, 105, 55, 0.1);">
                             <p style="margin: 0; font-style: italic; color: #555; font-size: 1.1rem;">
-                                "Proving that communities can build their own infrastructure for care. One massage, one venue, one $10/year website at a time."
+                                "Proving you can build your own infrastructure for care. One massage, one venue, one $10/year website at a time."
                             </p>
                         </div>
                         <div style="margin-top: 2rem;">
                             <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
-                                <i class="fas fa-certificate" style="color: var(--pe-green); font-size: 1.2rem;"></i>
+                                <i aria-hidden="true" class="fas fa-certificate" style="color: var(--pe-green); font-size: 1.2rem;"></i>
                                 <span><strong>Licensed MT #013193</strong> - Professional credentials, superhero heart</span>
                             </div>
                             <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
-                                <i class="fas fa-handshake" style="color: var(--pe-green); font-size: 1.2rem;"></i>
+                                <i aria-hidden="true" class="fas fa-handshake" style="color: var(--pe-green); font-size: 1.2rem;"></i>
                                 <span><strong>50/50 Model Pioneer</strong> - No hidden fees, no upselling, no mission creep</span>
                             </div>
                             <div style="display: flex; align-items: center; gap: 1rem;">
-                                <i class="fas fa-code" style="color: var(--pe-green); font-size: 1.2rem;"></i>
+                                <i aria-hidden="true" class="fas fa-code" style="color: var(--pe-green); font-size: 1.2rem;"></i>
                                 <span><strong>Open Source Advocate</strong> - Building tools communities can own</span>
                             </div>
                         </div>
@@ -217,21 +217,21 @@
             <div class="services-grid">
                 <div class="service-card">
                     <div class="service-icon">
-                        <i class="fas fa-store"></i>
+                        <i aria-hidden="true" class="fas fa-store"></i>
                     </div>
                     <h3>Small Business Pop-ups</h3>
                     <p>Bring The People's Elbow to card shops, nail salons, fitness centers, boutiques, and other small businesses for events and community days.</p>
                 </div>
                 <div class="service-card">
                     <div class="service-icon">
-                        <i class="fas fa-heart"></i>
+                        <i aria-hidden="true" class="fas fa-heart"></i>
                     </div>
                     <h3>Host-Driven Fundraising</h3>
                     <p>You choose the cause - hyper-local community targets work best. Massage sessions raise funds for YOUR chosen community initiative.</p>
                 </div>
                 <div class="service-card">
                     <div class="service-icon">
-                        <i class="fas fa-calendar-alt"></i>
+                        <i aria-hidden="true" class="fas fa-calendar-alt"></i>
                     </div>
                     <h3>Community Events</h3>
                     <p>Special events, festivals, and community gatherings where people come together and could use some tension relief.</p>
@@ -249,26 +249,26 @@
                     <p class="equipment-tagline">Behind the superhero persona lies serious professional equipment.</p>
                     <div class="equipment-features">
                         <div class="feature-item">
-                            <i class="fas fa-chair"></i>
+                            <i aria-hidden="true" class="fas fa-chair"></i>
                             <span><strong>Professional Chair Massage Setup</strong> - Ergonomic, portable, and comfortable for clients of all sizes</span>
                         </div>
                         <div class="feature-item">
-                            <i class="fas fa-bolt"></i>
+                            <i aria-hidden="true" class="fas fa-bolt"></i>
                             <span><strong>Theragun Pro Plus</strong> - Professional-grade percussion therapy device for deep muscle treatment</span>
                         </div>
                         <div class="feature-item">
-                            <i class="fas fa-leaf"></i>
+                            <i aria-hidden="true" class="fas fa-leaf"></i>
                             <span><strong>Professional Topicals</strong> - Cryoderm pain relief gel with anti-inflammatory botanicals plus separate CBD topicals for enhanced treatment options</span>
                         </div>
                         <div class="feature-item">
-                            <i class="fas fa-wind"></i>
+                            <i aria-hidden="true" class="fas fa-wind"></i>
                             <span><strong>Fan, Mister, and Tent</strong> - Battery-powered fan with misting attachment and a pop-up tent so outdoor events stay bearable in the heat</span>
                         </div>
                     </div>
                 </div>
                 <div class="equipment-badge">
                     <div class="license-display">
-                        <i class="fas fa-certificate"></i>
+                        <i aria-hidden="true" class="fas fa-certificate"></i>
                         <span>Licensed MT #013193</span>
                         <p>Professional credentials meet superhero dedication</p>
                     </div>
@@ -356,7 +356,7 @@
                 <!-- Map will be implemented later -->
                 <div class="map-placeholder">
                     <div class="map-coming-soon">
-                        <i class="fas fa-map-marked-alt"></i>
+                        <i aria-hidden="true" class="fas fa-map-marked-alt"></i>
                         <p>Based in Woodstock, GA.</p>
                         <p class="small-text">Serving Cherokee, Cobb, and surrounding counties</p>
                     </div>
@@ -374,11 +374,11 @@
                     <p>Have questions about The People's Elbow? Want to learn more about our mutual aid massage service?</p>
                     <div class="contact-methods">
                         <div class="contact-method">
-                            <i class="fas fa-envelope"></i>
+                            <i aria-hidden="true" class="fas fa-envelope"></i>
                             <span>info@peoples-elbow.com</span>
                         </div>
                         <div class="contact-method">
-                            <i class="fab fa-instagram"></i>
+                            <i aria-hidden="true" class="fab fa-instagram"></i>
                             <span><a href="https://www.instagram.com/peoples_elbow_massage/" target="_blank" rel="noopener noreferrer">@peoples_elbow_massage</a></span>
                         </div>
                     </div>

--- a/js/price-drop.js
+++ b/js/price-drop.js
@@ -1,0 +1,80 @@
+// Steal-page signature beat: when the closing CTA scrolls into view, a gold slash
+// strikes through "$200" and "$10" stamps in, in the same hand-inked grammar as the
+// turnbuckle underlines. Pure progressive enhancement: reduced-motion / no-JS readers
+// get the plain, fully legible sentence (both numbers are real text in the DOM).
+import { animate, createTimeline, createSpring, svg, utils } from './vendor/anime.esm.min.js';
+
+(function () {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    // The one paragraph where $200 and $10 appear together (the cause-and-effect line).
+    const target = Array.from(document.querySelectorAll('p'))
+        .find((p) => /\$200\b/.test(p.textContent) && /\$10\b/.test(p.textContent));
+    if (!target) return;
+
+    // Wrap a literal token in a span without disturbing the surrounding text or reading order.
+    function wrapToken(root, token, className) {
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+        let node;
+        while ((node = walker.nextNode())) {
+            const idx = node.nodeValue.indexOf(token);
+            if (idx === -1) continue;
+            const after = node.splitText(idx);
+            after.nodeValue = after.nodeValue.slice(token.length);
+            const span = document.createElement('span');
+            span.className = className;
+            span.textContent = token;
+            node.parentNode.insertBefore(span, after);
+            return span;
+        }
+        return null;
+    }
+
+    const priceOld = wrapToken(target, '$200', 'pe-price-old');
+    const priceNew = wrapToken(target, '$10', 'pe-price-new');
+    if (!priceOld || !priceNew) return;
+
+    utils.set(priceOld, { display: 'inline-block', position: 'relative' });
+    utils.set(priceNew, { display: 'inline-block' });
+
+    // Strike SVG sized to the "$200" box (inline-block, so it never splits across a wrap).
+    const NS = 'http://www.w3.org/2000/svg';
+    const svgEl = document.createElementNS(NS, 'svg');
+    svgEl.setAttribute('class', 'pe-price-strike');
+    svgEl.setAttribute('viewBox', '0 0 100 40');
+    svgEl.setAttribute('preserveAspectRatio', 'none');
+    svgEl.setAttribute('aria-hidden', 'true');
+    const path = document.createElementNS(NS, 'path');
+    path.setAttribute('d', 'M3 27 C 28 19, 62 25, 97 13');
+    svgEl.appendChild(path);
+    priceOld.appendChild(svgEl);
+
+    const draw = svg.createDrawable(path);
+    utils.set(draw, { draw: '0 0' });
+
+    let fired = false;
+    function go() {
+        if (fired) return;
+        fired = true;
+        const tl = createTimeline();
+        tl.add(draw, { draw: ['0 0', '0 1'], duration: 380, ease: 'outExpo' });
+        tl.add(priceNew, {
+            scale: [0.4, 1.15, 1],
+            ease: createSpring({ stiffness: 300, damping: 12 }), duration: 320,
+        }, '-=120');
+    }
+
+    if ('IntersectionObserver' in window) {
+        const io = new IntersectionObserver((entries, obs) => {
+            entries.forEach((e) => {
+                if (!e.isIntersecting) return;
+                obs.unobserve(e.target);
+                if (document.fonts && document.fonts.ready) document.fonts.ready.then(go);
+                else go();
+            });
+        }, { rootMargin: '0px 0px -28% 0px', threshold: 0 });
+        io.observe(target);
+    } else {
+        go();
+    }
+})();

--- a/past-events.html
+++ b/past-events.html
@@ -6,6 +6,21 @@
     <title>Past Appearances | The People's Elbow</title>
     <meta name="description" content="Past People's Elbow appearances. Photos, recaps, receipts.">
     <meta name="robots" content="noindex, nofollow">
+    <link rel="canonical" href="https://peoples-elbow.com/past-events.html">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://peoples-elbow.com/past-events.html">
+    <meta property="og:title" content="Past Appearances | The People's Elbow">
+    <meta property="og:description" content="Past People's Elbow appearances. Photos, recaps, receipts.">
+    <meta property="og:image" content="https://peoples-elbow.com/images/logo.png">
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://peoples-elbow.com/past-events.html">
+    <meta name="twitter:title" content="Past Appearances | The People's Elbow">
+    <meta name="twitter:description" content="Past People's Elbow appearances. Photos, recaps, receipts.">
+    <meta name="twitter:image" content="https://peoples-elbow.com/images/logo.png">
 
     <link rel="shortcut icon" href="images/favicon-32.png" type="image/png">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">

--- a/privacy.html
+++ b/privacy.html
@@ -52,7 +52,7 @@
                         If you use the Lead-o-Tron CRM and choose to sign in with Google, the app requests access to Google Drive with the <code>drive.file</code> scope. This means:
                     </p>
                     <ul style="line-height: 2; margin-bottom: 1rem; color: #333; padding-left: 1.5rem;">
-                        <li>The app can only see files <em>it created</em> — not your other Drive files.</li>
+                        <li>The app can only see files <em>it created</em>, not your other Drive files.</li>
                         <li>Your CRM data is stored as a single JSON file in <em>your</em> Google Drive account.</li>
                         <li>We cannot read it, modify it, or access it. It is yours.</li>
                         <li>You can delete it from Drive at any time and it's gone.</li>
@@ -63,7 +63,7 @@
 
                     <h2 style="color: #006937; margin-bottom: 1rem;">Third Parties</h2>
                     <p style="line-height: 1.7; margin-bottom: 2rem; color: #333;">
-                        The only third parties involved in the CRM's Drive sync are Google (OAuth + Drive API). Google's own privacy policy governs how Google handles your authentication and Drive data. We have no relationship with that data. The site also uses Cloudflare for hosting and DNS — their policies apply to infrastructure-level data.
+                        The only third parties involved in the CRM's Drive sync are Google (OAuth + Drive API). Google's own privacy policy governs how Google handles your authentication and Drive data. We have no relationship with that data. The site also uses Cloudflare for hosting and DNS. Their policies apply to infrastructure-level data.
                     </p>
 
                     <h2 style="color: #006937; margin-bottom: 1rem;">Contact Forms</h2>

--- a/steal-this-site.html
+++ b/steal-this-site.html
@@ -49,7 +49,7 @@
         <section class="quick-start" style="background: linear-gradient(135deg, #006937 0%, #008a47 100%); color: white; padding: 4rem 0;">
             <div class="container">
                 <div style="max-width: 900px; margin: 0 auto; text-align: center;">
-                    <h2 style="color: #ffd700; font-size: 2.5rem; margin-bottom: 2rem;">Copy This Entire Site for $10/Year</h2>
+                    <h2 class="section-title" style="color: #ffd700; font-size: 2.5rem; margin-bottom: 2rem;">All of This Runs on $10/Year</h2>
                     <p style="font-size: 1.3rem; margin-bottom: 3rem; line-height: 1.6;">
                         Everything you're seeing runs on <strong>Cloudflare</strong> for about $10 a year: forms, database, real-time updates, mobile-responsive design. No vendor lock-in, no hidden fees, no corporate dependencies.
                     </p>
@@ -68,7 +68,7 @@
                         <div style="background: rgba(255, 255, 255, 0.1); padding: 2rem; border-radius: 8px;">
                             <div style="font-size: 2rem; margin-bottom: 1rem;">🔧</div>
                             <h3 style="color: #ffd700; margin-bottom: 1rem;">Full Control</h3>
-                            <p>Your code, your data, your community. Own your infrastructure.</p>
+                            <p>Your code, your data, no platform sitting between you and either one.</p>
                         </div>
                     </div>
                 </div>
@@ -122,7 +122,7 @@
                         <div style="margin-top: 1.25rem; display: inline-block; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,215,0,0.25); border-radius: 8px; padding: 0.9rem 1.5rem; text-align: left; max-width: 480px;">
                             <p style="margin: 0 0 0.4rem 0; font-size: 0.85rem; color: #ffd700; font-weight: bold;">💡 Use it like a desktop app</p>
                             <p style="margin: 0; font-size: 0.82rem; color: #aaa; line-height: 1.5;">
-                                In Chrome or Edge: open the CRM, then go to the browser menu → <em>Save and share</em> → <em>Install page as app</em>. It opens in its own window with no browser chrome. Your data persists between sessions — it's just a webpage that behaves like software.
+                                In Chrome or Edge: open the CRM, then go to the browser menu → <em>Save and share</em> → <em>Install page as app</em>. It opens in its own window with no browser chrome. Your data persists between sessions. It's just a webpage that behaves like software.
                             </p>
                         </div>
                         <p style="margin-top: 1rem; font-size: 0.82rem; color: #666;">
@@ -137,7 +137,14 @@
         <section style="padding: 4rem 0; background: #f9f9f9;">
             <div class="container">
                 <div style="max-width: 800px; margin: 0 auto;">
-                    <h2 style="text-align: center; margin-bottom: 3rem; color: #006937; font-size: 2.2rem;">How to Steal It</h2>
+                    <h2 class="section-title" style="text-align: center; margin-bottom: 1.5rem; color: #006937; font-size: 2.2rem;">How to Steal It</h2>
+
+                    <div style="max-width: 760px; margin: 0 auto 3rem; background: #f0f8f0; border: 2px solid #006937; border-radius: 8px; padding: 1.75rem 2rem; text-align: center;">
+                        <p style="margin: 0 0 0.75rem 0; font-size: 1.15rem; color: #006937; font-weight: bold;">The easy way: hand it to your AI.</p>
+                        <p style="margin: 0; line-height: 1.6; color: #333;">
+                            Give <a href="https://github.com/degenai/peoples-elbow/blob/main/STEAL-THIS-SITE.md" target="_blank" rel="noopener noreferrer" style="color: #006937; text-decoration: underline;"><code>STEAL-THIS-SITE.md</code></a> to your AI coding agent and talk about it, or open a fresh session and say <em>"I want to make a Cloudflare and GitHub Pages website."</em> That's the whole job now. Prefer to do it by hand? The steps below still work.
+                        </p>
+                    </div>
                     
                     <div style="display: flex; flex-direction: column; gap: 3rem;">
                         <!-- Step 1 -->
@@ -196,7 +203,7 @@
         <section style="padding: 4rem 0; background: white;">
             <div class="container">
                 <div style="max-width: 900px; margin: 0 auto;">
-                    <h2 style="text-align: center; margin-bottom: 3rem; color: #006937; font-size: 2.2rem;">What You're Actually Getting</h2>
+                    <h2 class="section-title" style="text-align: center; margin-bottom: 3rem; color: #006937; font-size: 2.2rem;">What You're Actually Getting</h2>
                     
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 2rem;">
                         <div style="border: 2px solid #e0e0e0; padding: 2rem; border-radius: 8px;">
@@ -240,7 +247,7 @@
                                 <li>Mutual aid principles embedded</li>
                                 <li>Transparent development process</li>
                                 <li>No data collection or tracking</li>
-                                <li>Designed for community ownership</li>
+                                <li>Built for your own control</li>
                             </ul>
                         </div>
                     </div>
@@ -276,14 +283,14 @@
         <section style="padding: 4rem 0; background: linear-gradient(135deg, #006937 0%, #004225 100%); color: white; text-align: center;">
             <div class="container">
                 <div style="max-width: 600px; margin: 0 auto;">
-                    <h2 style="color: #ffd700; font-size: 2.3rem; margin-bottom: 2rem;">Go Build Your Own</h2>
+                    <h2 class="section-title" style="color: #ffd700; font-size: 2.3rem; margin-bottom: 2rem;">Go Build Your Own</h2>
                     <p style="font-size: 1.2rem; margin-bottom: 3rem; line-height: 1.6;">
                         Stop renting a website for $200 a year from a platform that doesn't share your values. The tools are cheap and good now. Go spin up your own $10 site, and let this be the reference you start from.
                     </p>
                     
                     <div style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
                         <a href="https://github.com/degenai/peoples-elbow" style="background: #ffd700; color: #006937; padding: 1rem 2rem; border-radius: 6px; text-decoration: none; font-weight: bold; display: inline-block; transition: all 0.3s ease;">
-                            🚀 Fork on GitHub
+                            🚀 Get the Code on GitHub
                         </a>
                         <a href="/changelog.html" style="background: rgba(255, 255, 255, 0.2); color: white; padding: 1rem 2rem; border-radius: 6px; text-decoration: none; font-weight: bold; display: inline-block;">
                             📖 See How We Built It
@@ -304,5 +311,7 @@
     <!-- JavaScript -->
     <script src="js/components.js"></script>
     <script src="js/main.js"></script>
+    <script type="module" src="js/reveal.js"></script>
+    <script type="module" src="js/price-drop.js"></script>
 </body>
 </html>

--- a/wiki.html
+++ b/wiki.html
@@ -5,6 +5,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Wiki Starter Kit | The People's Elbow</title>
     <meta name="robots" content="noindex, nofollow">
+    <meta name="description" content="Build a personal knowledge graph with Claude and Obsidian. No coding required. A free starter kit from The People's Elbow.">
+    <link rel="canonical" href="https://peoples-elbow.com/wiki.html">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://peoples-elbow.com/wiki.html">
+    <meta property="og:title" content="Wiki Starter Kit | The People's Elbow">
+    <meta property="og:description" content="Build a personal knowledge graph with Claude and Obsidian. No coding required.">
+    <meta property="og:image" content="https://peoples-elbow.com/images/logo.png">
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://peoples-elbow.com/wiki.html">
+    <meta name="twitter:title" content="Wiki Starter Kit | The People's Elbow">
+    <meta name="twitter:description" content="Build a personal knowledge graph with Claude and Obsidian. No coding required.">
+    <meta name="twitter:image" content="https://peoples-elbow.com/images/logo.png">
+
     <link rel="shortcut icon" href="images/favicon-32.png" type="image/png">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Bangers&family=Montserrat:wght@400;700&display=swap">
@@ -30,7 +47,7 @@
 
                     <p style="line-height: 1.7; margin-bottom: 2rem;">Everything is local files on your computer. Nothing gets uploaded. You own it.</p>
 
-                    <p style="line-height: 1.7; margin-bottom: 2rem;">The kit is bare bones on purpose. The structure, the procedures, the workflow — all of it grows around you. Your wiki won't look like anyone else's.</p>
+                    <p style="line-height: 1.7; margin-bottom: 2rem;">The kit is bare bones on purpose. The structure, the procedures, the workflow: all of it grows around you. Your wiki won't look like anyone else's.</p>
 
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.5rem; margin: 2rem 0;">
                         <div style="border: 2px solid #e0e0e0; padding: 1.5rem; border-radius: 8px; background: white;">
@@ -51,7 +68,7 @@
                         <a href="wiki-starter-kit.zip" style="background: #006937; color: white; padding: 1rem 2.5rem; border-radius: 6px; text-decoration: none; font-weight: bold; font-size: 1.1rem; display: inline-block; transition: all 0.3s ease;">
                             <i class="fas fa-download"></i> &nbsp;Download Starter Kit
                         </a>
-                        <p style="margin-top: 1rem; color: #888; font-size: 0.85rem;">ZIP file — unzip, point Claude Code at it, start talking</p>
+                        <p style="margin-top: 1rem; color: #888; font-size: 0.85rem;">ZIP file: unzip, point Claude Code at it, start talking</p>
                     </div>
 
                     <h2 style="color: #006937; text-align: center; margin: 3rem 0 2rem;">How It Works</h2>


### PR DESCRIPTION
Visual flair (now beyond the homepage):
- The hand-inked gold "turnbuckle" underline now draws on scroll on book.html, calendar.html, and the four real section headers of steal-this-site.html, not just index. reveal.js loads on those pages (it self-bails on the card-deal it has no section for).
- New js/price-drop.js: on the steal page's closing CTA, a gold slash strikes "$200" and "$10" stamps in, in the same hand-inked grammar.
- Cross-page View Transitions (CSS @view-transition) give an app-like green "tag-in" between pages on Chromium; everything else hard-navigates as before. Gated by prefers-reduced-motion.
- Steal-page copy aligned to the homepage's build-your-own / $10 thesis.

Mop-up:
- SEO/social meta added where missing: book.html (Twitter), chat.html (full description + canonical + OG + Twitter), past-events.html and wiki.html (canonical + OG + Twitter, plus a description on wiki).
- aria-hidden on 25 decorative Font Awesome icons across index.html (17), dashboard.html (7), and changelog.html (1).
- Removed 6 user-facing em dashes: crm.html demo banner, steal-this-site.html, privacy.html (x2), wiki.html (x2).
- Copy: "Designed for community ownership" -> "Built for your own control"; the #who quote now reads "Proving you can build your own infrastructure".

Deliberately left for review: console.error/warn kept (only fires on failure, never shown to users); auth-page meta (dashboard/login/crm/utility/404, intentionally bare); the crm/utility anime v3->v4 migration; ~19 em dashes in the internal auth-gated woodstock-plan.html draft.