### PR TITLE
Funnel every page toward booking, and give Hustle House a home on the homepage

### DIFF
--- a/book.html
+++ b/book.html
@@ -38,6 +38,34 @@
             </div>
         </section>
 
+        <section class="book-menu-section">
+            <div class="container">
+                <h2 class="section-title">The Menu</h2>
+                <p class="book-menu-intro">People's Elbow at Hustle House. Chair or table, whatever fits the day. Sessions are built around preparation and recovery: gearing up for an event or bouncing back after one. You do not have to be an athlete, everybody preps for something and recovers from something.</p>
+                <div class="book-menu-grid">
+                    <div class="book-menu-card">
+                        <span class="book-menu-dur">15 min</span>
+                        <span class="book-menu-price">$25</span>
+                        <span class="book-menu-desc">A quick reset. Neck, shoulders, and back between sets or on a lunch break.</span>
+                    </div>
+                    <div class="book-menu-card featured">
+                        <span class="book-menu-dur">30 min</span>
+                        <span class="book-menu-price">$45</span>
+                        <span class="book-menu-desc">The popular middle. Enough time to actually chase down what is bugging you.</span>
+                    </div>
+                    <div class="book-menu-card">
+                        <span class="book-menu-dur">60 min</span>
+                        <span class="book-menu-price">$85</span>
+                        <span class="book-menu-desc">The full session. Head to toe, or go deep on one area. Your call.</span>
+                    </div>
+                </div>
+                <div class="book-addons">
+                    <p><i class="fas fa-plus-circle" aria-hidden="true"></i> <strong>Add to any session:</strong> <strong>Cryoderm</strong> topical finish &middot; <strong>scraping</strong> (instrument-assisted soft-tissue work / gua sha)</p>
+                    <p class="book-firstvisit"><i class="fas fa-gift" aria-hidden="true"></i> <strong>First visit?</strong> Your first 15-minute massage is free, a $25 value. Or apply that $25 toward a 30- or 60-minute session.</p>
+                </div>
+            </div>
+        </section>
+
         <section class="book-widget-section">
             <div class="container">
                 <!-- Availability note slot. Populated by JS when the Square API proxy is wired up. Hidden by default. -->

--- a/components/footer.html
+++ b/components/footer.html
@@ -7,7 +7,7 @@
             <div class="footer-info">
                 <p>The People's Elbow: Massage Therapy &amp; Mutual Aid Fundraising</p>
                 <p>License #MT013193</p>
-                <p>&copy; 2025&ndash;2026 The People's Elbow &middot; <a href="privacy.html" style="color: inherit; text-decoration: underline;">Privacy Policy</a> &middot; <a href="past-events.html" style="color: inherit; text-decoration: underline;">Past Appearances</a></p>
+                <p>&copy; 2025&ndash;2026 The People's Elbow &middot; <a href="book.html" style="color: inherit; text-decoration: underline;">Book a Session</a> &middot; <a href="privacy.html" style="color: inherit; text-decoration: underline;">Privacy Policy</a> &middot; <a href="past-events.html" style="color: inherit; text-decoration: underline;">Past Appearances</a></p>
             </div>
             <div class="footer-quote">
                 <p>"Stay weird. Stay kind. Drop elbows with love."</p>

--- a/css/main.css
+++ b/css/main.css
@@ -2515,3 +2515,204 @@ nav ul li a.active {
         font-size: 1.8rem;
     }
 }
+
+/* ============================================================
+   People's Elbow at Hustle House - homepage residency section
+   ============================================================ */
+.hustle-house {
+    padding: var(--space-xl) 0;
+    background: var(--pe-white);
+}
+
+.hh-inner {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    gap: var(--space-xl);
+    align-items: center;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+.hh-kicker {
+    display: inline-block;
+    background: var(--pe-green-dark);
+    color: var(--pe-gold);
+    padding: 0.4rem 1rem;
+    border-radius: 999px;
+    font-size: 0.9rem;
+    font-weight: 700;
+    margin-bottom: var(--space-md);
+}
+
+.hh-lede p {
+    line-height: 1.7;
+    color: var(--pe-text-dark);
+    margin-bottom: var(--space-md);
+}
+
+.hh-offer {
+    background: var(--pe-light-gray);
+    border-left: 4px solid var(--pe-gold);
+    padding: var(--space-md);
+    border-radius: 6px;
+}
+
+.hh-lede .btn {
+    margin-top: var(--space-sm);
+}
+
+.hh-menu {
+    background: var(--pe-green);
+    color: var(--pe-white);
+    border-radius: 12px;
+    padding: var(--space-lg);
+    box-shadow: 0 6px 20px rgba(var(--pe-green-rgb), 0.25);
+}
+
+.hh-menu-title {
+    font-family: var(--font-heading);
+    color: var(--pe-gold);
+    font-size: 1.8rem;
+    text-align: center;
+    letter-spacing: 1px;
+    margin-bottom: var(--space-md);
+}
+
+.hh-menu-list {
+    list-style: none;
+    margin: 0 0 var(--space-md);
+    padding: 0;
+}
+
+.hh-menu-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 0.6rem 0;
+    border-bottom: 1px dashed rgba(255, 255, 255, 0.25);
+    font-size: 1.1rem;
+}
+
+.hh-menu-list li:last-child {
+    border-bottom: none;
+}
+
+.hh-dur {
+    font-weight: 700;
+}
+
+.hh-price {
+    font-family: var(--font-heading);
+    color: var(--pe-gold);
+    font-size: 1.4rem;
+    letter-spacing: 0.5px;
+}
+
+.hh-menu-note {
+    font-size: 0.9rem;
+    line-height: 1.55;
+    opacity: 0.95;
+}
+
+@media (max-width: 768px) {
+    .hh-inner {
+        grid-template-columns: 1fr;
+        gap: var(--space-lg);
+    }
+}
+
+/* ============================================================
+   book.html - the menu / offerings block
+   ============================================================ */
+.book-menu-section {
+    padding: var(--space-xl) 0 0;
+    background: var(--pe-white);
+}
+
+.book-menu-section .section-title {
+    font-family: var(--font-heading);
+    font-size: 2.2rem;
+    color: var(--pe-green-dark);
+    text-align: center;
+    margin-bottom: var(--space-md);
+}
+
+.book-menu-intro {
+    max-width: 760px;
+    margin: 0 auto var(--space-lg);
+    text-align: center;
+    line-height: 1.7;
+    color: var(--pe-text-dark);
+}
+
+.book-menu-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--space-lg);
+    max-width: 1000px;
+    margin: 0 auto var(--space-lg);
+}
+
+.book-menu-card {
+    background: var(--pe-light-gray);
+    border-radius: 10px;
+    padding: var(--space-lg);
+    text-align: center;
+    border-top: 4px solid var(--pe-green);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+}
+
+.book-menu-card.featured {
+    border-top-color: var(--pe-gold);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.1);
+}
+
+.book-menu-dur {
+    font-family: var(--font-heading);
+    font-size: 1.5rem;
+    color: var(--pe-green-dark);
+    letter-spacing: 0.5px;
+}
+
+.book-menu-price {
+    font-family: var(--font-heading);
+    font-size: 2.4rem;
+    color: var(--pe-green);
+}
+
+.book-menu-card.featured .book-menu-price {
+    color: var(--pe-orange);
+}
+
+.book-menu-desc {
+    font-size: 0.92rem;
+    line-height: 1.5;
+    color: var(--pe-text-dark);
+}
+
+.book-addons {
+    max-width: 760px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.book-addons p {
+    line-height: 1.6;
+    margin-bottom: var(--space-sm);
+    color: var(--pe-text-dark);
+}
+
+.book-addons i {
+    color: var(--pe-green);
+    margin-right: 0.35rem;
+}
+
+.book-firstvisit {
+    background: var(--pe-light-gray);
+    border-left: 4px solid var(--pe-gold);
+    padding: var(--space-md);
+    border-radius: 6px;
+    display: inline-block;
+}

--- a/index.html
+++ b/index.html
@@ -63,8 +63,8 @@
             <p class="tagline">Licensed hands. Half the money stays on your block.</p>
             <p class="hero-subtitle">Fighting the Forces of Tension, one elbow at a time!</p>
             <div class="hero-buttons">
-                <a href="#host" class="btn btn-primary">Join the Convention</a>
-                <a href="#mission" class="btn btn-secondary">Learn More</a>
+                <a href="book.html" class="btn btn-primary">Book a Session</a>
+                <a href="#host" class="btn btn-secondary">Join the Convention</a>
             </div>
         </div>
     </section>
@@ -235,6 +235,30 @@
                     </div>
                     <h3>Community Events</h3>
                     <p>Special events, festivals, and community gatherings where people come together and could use some tension relief.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- People's Elbow at Hustle House -->
+    <section id="hustle-house" class="hustle-house">
+        <div class="container">
+            <h2 class="section-title">People's Elbow at Hustle House</h2>
+            <div class="hh-inner">
+                <div class="hh-lede">
+                    <span class="hh-kicker"><i class="fas fa-calendar-day" aria-hidden="true"></i> Every Wednesday &middot; Hustle House Health &amp; Wellness, Woodstock GA</span>
+                    <p>Your weekly spot for licensed bodywork. Drop in for a quick reset or settle in for a full hour on the table. Whether you are gearing up for an event or recovering from one, the work meets you where you are. Preparation and recovery, and you do not have to be an athlete to need either.</p>
+                    <p class="hh-offer"><i class="fas fa-gift" aria-hidden="true"></i> <strong>First visit?</strong> Your first 15-minute massage is free, a $25 value. Or put that $25 toward a 30- or 60-minute session.</p>
+                    <a href="book.html" class="btn btn-primary">See the Menu &amp; Book &rarr;</a>
+                </div>
+                <div class="hh-menu">
+                    <h3 class="hh-menu-title">The Menu</h3>
+                    <ul class="hh-menu-list">
+                        <li><span class="hh-dur">15 min</span> <span class="hh-price">$25</span></li>
+                        <li><span class="hh-dur">30 min</span> <span class="hh-price">$45</span></li>
+                        <li><span class="hh-dur">60 min</span> <span class="hh-price">$85</span></li>
+                    </ul>
+                    <p class="hh-menu-note">Chair or table, whatever fits. Add <strong>Cryoderm</strong> or <strong>scraping</strong> (instrument-assisted soft-tissue work) to any session.</p>
                 </div>
             </div>
         </div>

--- a/past-events.html
+++ b/past-events.html
@@ -135,6 +135,16 @@
 
             </div>
         </section>
+
+        <!-- Closing booking CTA -->
+        <section class="book-banner" style="margin-top: 0;">
+            <div class="book-banner-inner">
+                <h2>Want This Energy For Yourself?</h2>
+                <p class="book-banner-sub">Catch a session every Wednesday at Hustle House Health &amp; Wellness in Woodstock, GA. No upselling, no membership traps.</p>
+                <a href="book.html" class="btn">Book a Session &rarr;</a>
+                <p style="margin-top: 1rem; font-size: 0.95rem;">Or <a href="index.html#host" style="color: var(--pe-green-dark); font-weight: 700; text-decoration: underline;">host The People's Elbow at your venue &rarr;</a></p>
+            </div>
+        </section>
     </main>
 
     <!-- Universal Footer Component -->


### PR DESCRIPTION
Applies the "wide funnel, every CTA ends at booking" pattern to peoples-elbow.com.

## What changed
- **Homepage hero** now leads with **Book a Session** (Convention kept as the secondary CTA so the host funnel survives).
- New dedicated **People's Elbow at Hustle House** section: Wednesday residency, the menu (15 min $25 / 30 min $45 / 60 min $85, chair or table), Cryoderm + scraping add-ons, a free first 15-minute massage for new clients, prep-and-recovery framing. Links to book.html.
- **book.html** gained a "The Menu" block (the three lengths, add-ons, first-visit offer) above the Square widget, so the QR target mirrors the flyer.
- **Footer** Book a Session link site-wide; **past-events.html** closing booking CTA.
- Styles for the new section + book menu in css/main.css.

Static HTML/CSS only (no D1), so the Cloudflare preview should render true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)