### PR TITLE
🧹 [code health] Remove unused DEFAULT_VENUE_TYPE constant

### DIFF
--- a/js/crm/data-normalizer.js
+++ b/js/crm/data-normalizer.js
@@ -25,7 +25,6 @@ const SCHEMA_VERSION = 2;
 // than reaching into DEFAULTS for keys that may not exist yet — the schema
 // contract is the source of truth, and this keeps the normalizer self-contained.
 const DEFAULT_SOURCE = 'field';
-const DEFAULT_VENUE_TYPE = '';
 const DEFAULT_SCORE = 3; // middle of the 1-5 range
 
 // Ids end up in HTML attribute positions (data-id="...") all over the UI. An id


### PR DESCRIPTION
🎯 **What:** Removed unused `DEFAULT_VENUE_TYPE` constant from `js/crm/data-normalizer.js`.
💡 **Why:** Reduces dead code, improving maintainability.
✅ **Verification:** Ran test suite (`js/crm/data-normalizer.test.js`); no behavior regressions were introduced. Code review passed.
✨ **Result:** Cleaned up unused variable reference, reducing mental overhead.

---
*PR created automatically by Jules for task [1211321014678311755](https://jules.google.com/task/1211321014678311755) started by @degenai*