### PR TITLE
🧹 [Remove Unused Code] Remove generateDateStr from js/crm/utils.js

### DIFF
--- a/_deprecated/crm-api-local.js
+++ b/_deprecated/crm-api-local.js
@@ -1,4 +1,4 @@
-import { generateId, generateDateStr } from './utils.js';
+import { generateId } from './utils.js';
 import { normalizeLeadsData } from './data-normalizer.js';
 
 const STORAGE_KEY = 'leadOTron_demoData';
@@ -267,7 +267,7 @@ export const CrmApi = {
   },
 
   async createLead(data) {
-    const newLead = { ...data, id: generateId(), created: generateDateStr(), lastVisit: null };
+    const newLead = { ...data, id: generateId(), created: new Date().toISOString(), lastVisit: null };
     this.localState.leads.push(newLead);
     await this.saveState();
     return newLead;

--- a/js/crm/utils.js
+++ b/js/crm/utils.js
@@ -2,10 +2,6 @@ export function generateId() {
   return crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).substring(2, 15);
 }
 
-export function generateDateStr(date = new Date()) {
-  return date.toISOString();
-}
-
 export function getTimeSince(dateStr) {
   if (!dateStr) return { days: Infinity, weeks: Infinity, formatted: 'Never' };
 


### PR DESCRIPTION
🎯 **What:** The `generateDateStr` wrapper function in `js/crm/utils.js` was identified as dead code and removed. The single lingering reference in `_deprecated/crm-api-local.js` was replaced with the inline equivalent.
💡 **Why:** Removing unused functions improves codebase maintainability, reduces confusion for future developers, and lowers the testing burden.
✅ **Verification:** Verified by confirming the target file and deprecated file passes `node -c` syntax check and `js/crm/utils.test.js` continues to pass its existing assertions smoothly.
✨ **Result:** A cleaner utility file with completely eliminated dead code, leaving no trailing references behind.

---
*PR created automatically by Jules for task [7037082922002760665](https://jules.google.com/task/7037082922002760665) started by @degenai*